### PR TITLE
[loki-distributed] Add optional appProtocol to memcached services

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.5.0
-version: 0.51.0
+version: 0.52.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.51.0](https://img.shields.io/badge/Version-0.51.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
+![Version: 0.52.0](https://img.shields.io/badge/Version-0.52.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.0](https://img.shields.io/badge/AppVersion-2.5.0-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -242,6 +242,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | loki.serviceAnnotations | object | `{}` | Common annotations for all loki services |
 | loki.storageConfig | object | `{"boltdb_shipper":{"active_index_directory":"/var/loki/index","cache_location":"/var/loki/cache","cache_ttl":"168h","shared_store":"filesystem"},"filesystem":{"directory":"/var/loki/chunks"}}` | Check https://grafana.com/docs/loki/latest/configuration/#storage_config for more info on how to configure storages |
 | loki.structuredConfig | object | `{}` | Structured loki configuration, takes precedence over `loki.config`, `loki.schemaConfig`, `loki.storageConfig` |
+| memcached.appProtocol | string | `""` | Adds the appProtocol field to the memcached services. This allows memcached to work with istio protocol selection. Ex: "http" or "tcp" |
 | memcached.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for memcached containers |
 | memcached.image.pullPolicy | string | `"IfNotPresent"` | Memcached Docker image pull policy |
 | memcached.image.registry | string | `"docker.io"` | The Docker registry for the memcached |

--- a/charts/loki-distributed/templates/memcached-chunks/service-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/service-memcached-chunks.yaml
@@ -20,6 +20,9 @@ spec:
       port: 11211
       targetPort: http
       protocol: TCP
+      {{- if .Values.memcached.appProtocol }}
+      appProtocol: {{ .Values.memcached.appProtocol }}
+      {{- end }}
     - name: http-metrics
       port: 9150
       targetPort: http-metrics

--- a/charts/loki-distributed/templates/memcached-frontend/service-memcached-frontend.yaml
+++ b/charts/loki-distributed/templates/memcached-frontend/service-memcached-frontend.yaml
@@ -20,6 +20,9 @@ spec:
       port: 11211
       targetPort: http
       protocol: TCP
+      {{- if .Values.memcached.appProtocol }}
+      appProtocol: {{ .Values.memcached.appProtocol }}
+      {{- end }}
     - name: http-metrics
       port: 9150
       targetPort: http-metrics

--- a/charts/loki-distributed/templates/memcached-index-queries/service-memcached-index-queries.yaml
+++ b/charts/loki-distributed/templates/memcached-index-queries/service-memcached-index-queries.yaml
@@ -20,6 +20,9 @@ spec:
       port: 11211
       targetPort: http
       protocol: TCP
+      {{- if .Values.memcached.appProtocol }}
+      appProtocol: {{ .Values.memcached.appProtocol }}
+      {{- end }}
     - name: http-metrics
       port: 9150
       targetPort: http-metrics

--- a/charts/loki-distributed/templates/memcached-index-writes/service-memcached-index-writes.yaml
+++ b/charts/loki-distributed/templates/memcached-index-writes/service-memcached-index-writes.yaml
@@ -20,6 +20,9 @@ spec:
       port: 11211
       targetPort: http
       protocol: TCP
+      {{- if .Values.memcached.appProtocol }}
+      appProtocol: {{ .Values.memcached.appProtocol }}
+      {{- end }}
     - name: http-metrics
       port: 9150
       targetPort: http-metrics

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1174,6 +1174,8 @@ memcached:
     allowPrivilegeEscalation: false
   # -- Common annotations for all memcached services
   serviceAnnotations: {}
+  # -- Adds the appProtocol field to the memcached services. This allows memcached to work with istio protocol selection. Ex: "http" or "tcp"
+  appProtocol: ""
 
 memcachedExporter:
   # -- Specifies whether the Memcached Exporter should be enabled


### PR DESCRIPTION
This PR addresses the same issue that was resolved in https://github.com/grafana/helm-charts/pull/1549, but for memcached instead.

With istio protocol selection, loki components are unable to communicate with the memcached services and throw the following error: 
```
level=error ts=2022-07-07T18:25:48.762006363Z caller=memcached.go:144 org_id=fake msg="Failed to get keys from memcached" keysrequested=1 err="memcache: unexpected line in get response: \"HTTP/1.1 400 Bad Request\\r\\n\""
level=error ts=2022-07-07T18:25:48.949472733Z caller=memcached.go:220 msg="failed to put to memcached" name=chunks err=null
level=warn ts=2022-07-07T18:25:48.949510324Z caller=background.go:127 msg="backgroundCache writeBackLoop Cache.Store fail" err="server=100.80.71.54:11211: memcache: unexpected response line from \"set\": \"HTTP/1.1 400 Bad Request\\r\\n\""
```

This can be resolved by setting `appProtocol: tcp` in the memcached services.  If appProtocol is left empty, then it will be ignored and not included in the service.