### PR TITLE
[loki-distributed] Add support for additional PVCs in the memcached-chunks statefulset

### DIFF
--- a/charts/loki-distributed/Chart.yaml
+++ b/charts/loki-distributed/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-distributed
 description: Helm chart for Grafana Loki in microservices mode
 type: application
 appVersion: 2.8.4
-version: 0.71.2
+version: 0.72.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-distributed/README.md
+++ b/charts/loki-distributed/README.md
@@ -1,6 +1,6 @@
 # loki-distributed
 
-![Version: 0.71.2](https://img.shields.io/badge/Version-0.71.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.4](https://img.shields.io/badge/AppVersion-2.8.4-informational?style=flat-square)
+![Version: 0.72.0](https://img.shields.io/badge/Version-0.72.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.4](https://img.shields.io/badge/AppVersion-2.8.4-informational?style=flat-square)
 
 Helm chart for Grafana Loki in microservices mode
 
@@ -343,6 +343,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcachedChunks.extraContainers | list | `[]` | Containers to add to the memcached-chunks pods |
 | memcachedChunks.extraEnv | list | `[]` | Environment variables to add to memcached-chunks pods |
 | memcachedChunks.extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to memcached-chunks pods |
+| memcachedChunks.extraVolumeMounts | list | `[]` | List of additional volumes to be mounted for the memcached-chunks statefulset |
 | memcachedChunks.hostAliases | list | `[]` | hostAliases to add |
 | memcachedChunks.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |
 | memcachedChunks.nodeSelector | object | `{}` | Node selector for memcached-chunks pods |
@@ -357,6 +358,7 @@ kubectl delete statefulset RELEASE_NAME-loki-distributed-querier -n LOKI_NAMESPA
 | memcachedChunks.serviceLabels | object | `{}` | Labels for memcached-chunks service |
 | memcachedChunks.terminationGracePeriodSeconds | int | `30` | Grace period to allow memcached-chunks to shutdown before it is killed |
 | memcachedChunks.tolerations | list | `[]` | Tolerations for memcached-chunks pods |
+| memcachedChunks.volumeClaimTemplates | list | `[]` | List of additional PVCs to be created for the memcached-chunks statefulset |
 | memcachedExporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | The SecurityContext for memcachedExporter containers |
 | memcachedExporter.enabled | bool | `false` | Specifies whether the Memcached Exporter should be enabled |
 | memcachedExporter.image.pullPolicy | string | `"IfNotPresent"` | Memcached Exporter Docker image pull policy |

--- a/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
+++ b/charts/loki-distributed/templates/memcached-chunks/statefulset-memcached-chunks.yaml
@@ -95,10 +95,15 @@ spec:
             {{- toYaml .Values.memcached.readinessProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.memcached.livenessProbe | nindent 12 }}
-          {{- if .Values.memcachedChunks.persistence.enabled }}
+          {{- if or .Values.memcachedChunks.persistence.enabled .Values.memcachedChunks.extraVolumeMounts }}
           volumeMounts:
+          {{- if .Values.memcachedChunks.persistence.enabled }}
             - name: data
               mountPath: /cache-state
+          {{- end }}
+          {{- if .Values.memcachedChunks.extraVolumeMounts }}
+            {{- toYaml .Values.memcachedChunks.extraVolumeMounts | nindent 12 }}
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.memcachedChunks.resources | nindent 12 }}
@@ -133,8 +138,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.memcachedChunks.persistence.enabled }}
+  {{- if or .Values.memcachedChunks.persistence.enabled .Values.memcachedChunks.volumeClaimTemplates }}
   volumeClaimTemplates:
+  {{- if .Values.memcachedChunks.persistence.enabled }}
     - metadata:
         name: data
       spec:
@@ -147,4 +153,8 @@ spec:
           requests:
             storage: {{ .Values.memcachedChunks.persistence.size | quote }}
   {{- end }}
+  {{- with .Values.memcachedChunks.volumeClaimTemplates }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/loki-distributed/values.yaml
+++ b/charts/loki-distributed/values.yaml
@@ -1710,6 +1710,10 @@ memcachedChunks:
     # If empty or set to null, no storageClassName spec is
     # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
     storageClass: null
+  # -- List of additional PVCs to be created for the memcached-chunks statefulset
+  volumeClaimTemplates: []
+  # -- List of additional volumes to be mounted for the memcached-chunks statefulset
+  extraVolumeMounts: []
 
 memcachedFrontend:
   # -- Specifies whether the Memcached frontend cache should be enabled


### PR DESCRIPTION
Adding the ability to add additional volumeClaimTemplates and volumeMounts to the memcached-chunks statefulset. 

This is needed for use cases where adding and mounting another PVC to memcached is required, such as implementing the extstore. This use case was explored in this blog https://grafana.com/blog/2023/08/23/how-we-scaled-grafana-cloud-logs-memcached-cluster-to-50tb-and-improved-reliability/.

Example of configuring these new fields:

```
memcachedChunks:
  volumeClaimTemplates:
    - metadata:
        name: data-extstore
      spec:
        accessModes:
          - ReadWriteOnce
        storageClassName: null
        resources:
          requests:
            storage: 100Gi
   extraVolumeMounts:
     - name: data-extstore
       mountPath: /extstore
```

