### PR TITLE
[tempo-distributed] add optional statefulset and traces_storage config for metrics generator

### DIFF
--- a/charts/tempo-distributed/Chart.yaml
+++ b/charts/tempo-distributed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tempo-distributed
 description: Grafana Tempo in MicroService mode
 type: application
-version: 1.7.1
+version: 1.8.0
 appVersion: 2.3.0
 engine: gotpl
 home: https://grafana.com/docs/tempo/latest/

--- a/charts/tempo-distributed/README.md
+++ b/charts/tempo-distributed/README.md
@@ -1,6 +1,6 @@
 # tempo-distributed
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 Grafana Tempo in MicroService mode
 
@@ -560,10 +560,11 @@ The memcached default args are removed and should be provided manually. The sett
 | metricsGenerator.annotations | object | `{}` | Annotations for the metrics-generator StatefulSet |
 | metricsGenerator.appProtocol | object | `{"grpc":null}` | Adds the appProtocol field to the metricsGenerator service. This allows metricsGenerator to work with istio protocol selection. |
 | metricsGenerator.appProtocol.grpc | string | `nil` | Set the optional grpc service protocol. Ex: "grpc", "http2" or "https" |
-| metricsGenerator.config | object | `{"metrics_ingestion_time_range_slack":"30s","processor":{"service_graphs":{"dimensions":[],"histogram_buckets":[0.1,0.2,0.4,0.8,1.6,3.2,6.4,12.8],"max_items":10000,"wait":"10s","workers":10},"span_metrics":{"dimensions":[],"histogram_buckets":[0.002,0.004,0.008,0.016,0.032,0.064,0.128,0.256,0.512,1.02,2.05,4.1]}},"registry":{"collection_interval":"15s","external_labels":{},"stale_duration":"15m"},"storage":{"path":"/var/tempo/wal","remote_write":[],"remote_write_flush_deadline":"1m","wal":null}}` | More information on configuration: https://grafana.com/docs/tempo/latest/configuration/#metrics-generator |
+| metricsGenerator.config | object | `{"metrics_ingestion_time_range_slack":"30s","processor":{"service_graphs":{"dimensions":[],"histogram_buckets":[0.1,0.2,0.4,0.8,1.6,3.2,6.4,12.8],"max_items":10000,"wait":"10s","workers":10},"span_metrics":{"dimensions":[],"histogram_buckets":[0.002,0.004,0.008,0.016,0.032,0.064,0.128,0.256,0.512,1.02,2.05,4.1]}},"registry":{"collection_interval":"15s","external_labels":{},"stale_duration":"15m"},"storage":{"path":"/var/tempo/wal","remote_write":[],"remote_write_flush_deadline":"1m","wal":null},"traces_storage":{"path":"/var/tempo/traces"}}` | More information on configuration: https://grafana.com/docs/tempo/latest/configuration/#metrics-generator |
 | metricsGenerator.config.processor.service_graphs.dimensions | list | `[]` | resource and span attributes and are added to the metrics if present. |
 | metricsGenerator.config.processor.span_metrics.dimensions | list | `[]` | Dimensions are searched for in the resource and span attributes and are added to the metrics if present. |
 | metricsGenerator.config.storage.remote_write | list | `[]` | https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write |
+| metricsGenerator.config.traces_storage | object | `{"path":"/var/tempo/traces"}` | Used by the local blocks processor to store a wal for traces. |
 | metricsGenerator.enabled | bool | `false` | Specifies whether a metrics-generator should be deployed |
 | metricsGenerator.extraArgs | list | `[]` | Additional CLI args for the metrics-generator |
 | metricsGenerator.extraEnv | list | `[]` | Environment variables to add to the metrics-generator pods |
@@ -575,7 +576,12 @@ The memcached default args are removed and should be provided manually. The sett
 | metricsGenerator.image.registry | string | `nil` | The Docker registry for the metrics-generator image. Overrides `tempo.image.registry` |
 | metricsGenerator.image.repository | string | `nil` | Docker image repository for the metrics-generator image. Overrides `tempo.image.repository` |
 | metricsGenerator.image.tag | string | `nil` | Docker image tag for the metrics-generator image. Overrides `tempo.image.tag` |
+| metricsGenerator.kind | string | `"Deployment"` | Kind of deployment [StatefulSet/Deployment] |
 | metricsGenerator.nodeSelector | object | `{}` | Node selector for metrics-generator pods |
+| metricsGenerator.persistence | object | `{"annotations":{},"enabled":false,"size":"10Gi","storageClass":null}` | Persistence configuration for metrics-generator |
+| metricsGenerator.persistence.annotations | object | `{}` | Annotations for metrics generator PVCs |
+| metricsGenerator.persistence.enabled | bool | `false` | Enable creating PVCs if you have kind set to StatefulSet. This disables using local disk or memory configured in walEmptyDir |
+| metricsGenerator.persistence.storageClass | string | `nil` | Storage class to be used. If defined, storageClassName: <storageClass>. If set to "-", storageClassName: "", which disables dynamic provisioning. If empty or set to null, no storageClassName spec is set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack). |
 | metricsGenerator.podAnnotations | object | `{}` | Annotations for metrics-generator pods |
 | metricsGenerator.podLabels | object | `{}` | Labels for metrics-generator pods |
 | metricsGenerator.ports | list | `[{"name":"grpc","port":9095,"service":true},{"name":"http-memberlist","port":7946,"service":false},{"name":"http-metrics","port":3100,"service":true}]` | Default ports |

--- a/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
+++ b/charts/tempo-distributed/templates/metrics-generator/statefulset-metrics-generator.yaml
@@ -1,7 +1,7 @@
-{{- if and (.Values.metricsGenerator.enabled) (eq .Values.metricsGenerator.kind "Deployment") }}
+{{- if and (.Values.metricsGenerator.enabled) (eq .Values.metricsGenerator.kind "StatefulSet") }}
 {{ $dict := dict "ctx" . "component" "metrics-generator" "memberlist" true }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "tempo.resourceName" $dict }}
   namespace: {{ .Release.Namespace }}
@@ -15,6 +15,10 @@ spec:
   minReadySeconds: 10
   replicas: {{ .Values.metricsGenerator.replicas }}
   revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
   selector:
     matchLabels:
       {{- include "tempo.selectorLabels" $dict | nindent 6 }}
@@ -126,9 +130,28 @@ spec:
           secret:
             secretName: {{ tpl .Values.license.secretName . }}
         {{- end }}
-        - name: wal
-          emptyDir: {{- toYaml .Values.metricsGenerator.walEmptyDir | nindent 12 }}
         {{- with .Values.metricsGenerator.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+  {{- if not .Values.metricsGenerator.persistence.enabled }}
+        - name: wal
+          emptyDir: {{- toYaml .Values.metricsGenerator.walEmptyDir | nindent 12 }}
+  {{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        {{- with .Values.metricsGenerator.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        name: wal
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.metricsGenerator.persistence.storageClass }}
+        storageClassName: {{ if (eq "-" .) }}""{{ else }}{{ . }}{{ end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.metricsGenerator.persistence.size | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/tempo-distributed/values.yaml
+++ b/charts/tempo-distributed/values.yaml
@@ -228,6 +228,8 @@ ingester:
 metricsGenerator:
   # -- Specifies whether a metrics-generator should be deployed
   enabled: false
+  # -- Kind of deployment [StatefulSet/Deployment]
+  kind: Deployment
   # -- Annotations for the metrics-generator StatefulSet
   annotations: {}
   # -- Number of replicas for the metrics-generator
@@ -293,6 +295,19 @@ metricsGenerator:
   nodeSelector: {}
   # -- Tolerations for metrics-generator pods
   tolerations: []
+  # -- Persistence configuration for metrics-generator
+  persistence:
+    # -- Enable creating PVCs if you have kind set to StatefulSet. This disables using local disk or memory configured in walEmptyDir
+    enabled: false
+    size: 10Gi
+    # -- Storage class to be used.
+    # If defined, storageClassName: <storageClass>.
+    # If set to "-", storageClassName: "", which disables dynamic provisioning.
+    # If empty or set to null, no storageClassName spec is
+    # set, choosing the default provisioner (gp2 on AWS, standard on GKE, AWS, and OpenStack).
+    storageClass: null
+    # -- Annotations for metrics generator PVCs
+    annotations: {}
   # -- The EmptyDir location where the /var/tempo will be mounted on. Defaults to local disk, can be set to memory.
   walEmptyDir: {}
     ## Here shows how to configure 1Gi memory as emptyDir.
@@ -341,6 +356,9 @@ metricsGenerator:
       # -- A list of remote write endpoints.
       # -- https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
       remote_write: []
+    # -- Used by the local blocks processor to store a wal for traces.
+    traces_storage:
+      path: /var/tempo/traces
     metrics_ingestion_time_range_slack: 30s
   service:
     # -- Annotations for Metrics Generator service
@@ -1090,6 +1108,8 @@ config: |
       {{- toYaml .Values.metricsGenerator.config.processor | nindent 6 }}
     storage:
       {{- toYaml .Values.metricsGenerator.config.storage | nindent 6 }}
+    traces_storage:
+      {{- toYaml .Values.metricsGenerator.config.traces_storage | nindent 6 }}
     registry:
       {{- toYaml .Values.metricsGenerator.config.registry | nindent 6 }}
     metrics_ingestion_time_range_slack: {{ .Values.metricsGenerator.config.metrics_ingestion_time_range_slack }}


### PR DESCRIPTION
Adding support for the new experimental metrics summary api capability https://grafana.com/docs/tempo/latest/api_docs/metrics-summary/

Specifically, the docs mention that this feature will cause the generator to use considerably more resources, including disk space. To handle this at scale and to ensure data persistence and availability, I am adding support for the metrics-generator to optionally be deployed as a statefulset with a pvc.

If `kind: StatefulSet` is set and persistence is enabled, then the metrics-generator will be deployed as a statefulset instead of a deployment and the walEmptyDir won't be used. To ensure backwards compatibility though, by default the metrics-generator is still a deployment with the walEmptyDir.

Additionally, the metrics summary api requires a new config `traces_storage`. This is used by the local blocks processor to store a wal for the traces. https://github.com/grafana/tempo/blob/main/modules/generator/config.go#L31
- Without this config, the following error is thrown 
```
level=warn ts=2023-11-29T19:29:38.039769755Z caller=server.go:1184 method=/tempopb.MetricsGenerator/PushSpans duration=5.298406ms msg=gRPC err="could not initialize processors: local blocks processor requires traces wal"
```